### PR TITLE
Update commonsdownloader.py

### DIFF
--- a/commonsdownloader.py
+++ b/commonsdownloader.py
@@ -47,7 +47,7 @@ def download_file(image_name, output_path, width=DEFAULT_WIDTH):
     logging.info("Downloading %s with width %s", image_name, width)
     contents, output_file_name = get_thumbnail_of_file(image_name, width)
     output_file_path = os.path.join(output_path, output_file_name)
-    with open(output_file_path, 'w') as f:
+    with open(output_file_path, 'wb') as f:
         logging.debug("Writing as %s" % output_file_path)
         f.write(contents)
     return output_file_path


### PR DESCRIPTION
output_file_path, 'wb' [instead of] output_file_path, 'w'
To open file image as binary file.
(This fixes a bug encountered under Windows XP
which resulted in a corrupted thumbnail).
